### PR TITLE
KISS Metrics alias method

### DIFF
--- a/lib/analytical/base.rb
+++ b/lib/analytical/base.rb
@@ -29,13 +29,6 @@ module Analytical
       # reported by an analytics service
       def set(data); ''; end
 
-      # KISS Metrics Only
-      # Alias allows linking two identities.
-      # It takes in two indentity strings to be linked together.
-      # analytical.alias_identity('foo','bar')
-      # See KISS Metrics 'alias' documentation at http://support.kissmetrics.com/apis/common-methods
-      def alias_identity(old_identity, new_identity); ''; end
-
       # This method generates the initialization javascript that an analytics service uses to track your site
       def init_javascript(location); ''; end
 

--- a/lib/analytical/base.rb
+++ b/lib/analytical/base.rb
@@ -32,9 +32,9 @@ module Analytical
       # KISS Metrics Only
       # Alias allows linking two identities.
       # It takes in two indentity strings to be linked together.
-      # analytical.alias('foo','bar')
+      # analytical.alias_identity('foo','bar')
       # See KISS Metrics 'alias' documentation at http://support.kissmetrics.com/apis/common-methods
-      def alias(old_identity, new_identity); ''; end
+      def alias_identity(old_identity, new_identity); ''; end
 
       # This method generates the initialization javascript that an analytics service uses to track your site
       def init_javascript(location); ''; end

--- a/lib/analytical/base.rb
+++ b/lib/analytical/base.rb
@@ -47,7 +47,9 @@ module Analytical
         end
       end
       def process_queued_commands
-        command_strings = @commands.collect {|c| send(*c) }
+        command_strings = @commands.collect do |c|
+          send(*c) if respond_to?(c.first)
+        end.compact
         @commands = []
         command_strings
       end

--- a/lib/analytical/base.rb
+++ b/lib/analytical/base.rb
@@ -29,6 +29,13 @@ module Analytical
       # reported by an analytics service
       def set(data); ''; end
 
+      # KISS Metrics Only
+      # Alias allows linking two identities.
+      # It takes in two indentity strings to be linked together.
+      # analytical.alias('foo','bar')
+      # See KISS Metrics 'alias' documentation at http://support.kissmetrics.com/apis/common-methods
+      def alias(old_identity, new_identity); ''; end
+
       # This method generates the initialization javascript that an analytics service uses to track your site
       def init_javascript(location); ''; end
 

--- a/lib/analytical/console.rb
+++ b/lib/analytical/console.rb
@@ -51,6 +51,12 @@ module Analytical
         HERE
       end
 
+      def alias(old_identity,new_identity)
+        check_for_console <<-HERE
+        console.log("Analytical Alias: #{old_identity} => #{new_identity}");
+        HERE
+      end
+
       private
 
       CONSOLE_JS_ESCAPE_MAP = {

--- a/lib/analytical/console.rb
+++ b/lib/analytical/console.rb
@@ -51,7 +51,7 @@ module Analytical
         HERE
       end
 
-      def alias(old_identity,new_identity)
+      def alias_identity(old_identity,new_identity)
         check_for_console <<-HERE
         console.log("Analytical Alias: #{old_identity} => #{new_identity}");
         HERE

--- a/lib/analytical/kiss_metrics.rb
+++ b/lib/analytical/kiss_metrics.rb
@@ -45,6 +45,10 @@ module Analytical
         "_kmq.push([\"set\", #{data.to_json}]);"
       end
 
+      def alias(old_identity, new_identity)
+        "_kmq.push([\"alias\", \"#{old_identity}\", \"#{new_identity}\"]);"
+      end
+
     end
   end
 end

--- a/lib/analytical/kiss_metrics.rb
+++ b/lib/analytical/kiss_metrics.rb
@@ -45,7 +45,7 @@ module Analytical
         "_kmq.push([\"set\", #{data.to_json}]);"
       end
 
-      def alias(old_identity, new_identity)
+      def alias_identity(old_identity, new_identity)
         "_kmq.push([\"alias\", \"#{old_identity}\", \"#{new_identity}\"]);"
       end
 

--- a/spec/analytical/base_spec.rb
+++ b/spec/analytical/base_spec.rb
@@ -1,11 +1,11 @@
 require File.expand_path(File.dirname(__FILE__) + '/../spec_helper')
 
 describe Analytical::Base::Api do
-  
+
   class BaseApiDummy
     include Analytical::Base::Api
   end
-  
+
   describe '#queue' do
     before(:each) do
       @api = BaseApiDummy.new(:parent=>mock('parent'))
@@ -30,7 +30,7 @@ describe Analytical::Base::Api do
       @api = BaseApiDummy.new(:parent=>mock('parent'))
       @api.commands = [[:a, 1, 2, 3], [:b, {:some=>:args}]]
       @api.stub!(:a).and_return('a')
-      @api.stub!(:b).and_return('b')      
+      @api.stub!(:b).and_return('b')
     end
     it 'should send each of the args arrays in the command list' do
       @api.should_receive(:a).with(1, 2, 3).and_return('a')
@@ -43,6 +43,10 @@ describe Analytical::Base::Api do
     it 'should clear the commands list' do
       @api.process_queued_commands
       @api.commands == []
+    end
+    it "should not store an unrecognized command" do
+      @api.commands << [:c, 1]
+      @api.process_queued_commands.should == ['a','b']
     end
   end
 
@@ -72,7 +76,7 @@ describe Analytical::Base::Api do
       @api.init_location(:some_location)
     end
     describe 'for a valid init location' do
-      before(:each) { @api.stub!(:init_location?).and_return(true) }      
+      before(:each) { @api.stub!(:init_location?).and_return(true) }
       it 'should set initialized to true' do
         @api.init_location(:some_location)
         @api.initialized.should be_true
@@ -92,5 +96,5 @@ describe Analytical::Base::Api do
       end
     end
   end
-  
+
 end

--- a/spec/analytical/kiss_metrics_spec.rb
+++ b/spec/analytical/kiss_metrics_spec.rb
@@ -38,13 +38,19 @@ describe "Analytical::KissMetrics::Api" do
       @api.set({:something=>'good', :b=>2}).should == "_kmq.push([\"set\", #{{:something=>'good', :b=>2}.to_json}]);"
     end
   end
+  describe '#alias' do
+    it 'should return a js string' do
+      @api = Analytical::KissMetrics::Api.new :parent=>@parent, :js_url_key=>'abcdef'
+      @api.alias('foo', 'bar').should == "_kmq.push([\"alias\", \"foo\", \"bar\"]);"
+    end
+  end
   describe '#init_javascript' do
     it 'should return the init javascript' do
       @api = Analytical::KissMetrics::Api.new :parent=>@parent, :js_url_key=>'abcdef'
       @api.init_javascript(:head_prepend).should == ''
       @api.init_javascript(:head_append).should == ''
       @api.init_javascript(:body_prepend).should =~ /i\.kissmetrics\.com/
-      @api.init_javascript(:body_prepend).should =~ /abcdef/      
+      @api.init_javascript(:body_prepend).should =~ /abcdef/
       @api.init_javascript(:body_append).should == ''
     end
   end

--- a/spec/analytical/kiss_metrics_spec.rb
+++ b/spec/analytical/kiss_metrics_spec.rb
@@ -38,10 +38,10 @@ describe "Analytical::KissMetrics::Api" do
       @api.set({:something=>'good', :b=>2}).should == "_kmq.push([\"set\", #{{:something=>'good', :b=>2}.to_json}]);"
     end
   end
-  describe '#alias' do
+  describe '#alias_identity' do
     it 'should return a js string' do
       @api = Analytical::KissMetrics::Api.new :parent=>@parent, :js_url_key=>'abcdef'
-      @api.alias('foo', 'bar').should == "_kmq.push([\"alias\", \"foo\", \"bar\"]);"
+      @api.alias_identity('foo', 'bar').should == "_kmq.push([\"alias\", \"foo\", \"bar\"]);"
     end
   end
   describe '#init_javascript' do


### PR DESCRIPTION
I'm already using analytical, and I need to use the alias method for KISS Metrics. I didn't want to write a bunch of hacky javascript so I did my best to extend the analytical api to include alias. 
