### PR TITLE
Bug: rails < 3.1 template is mispelled.

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -76,7 +76,7 @@ module Analytical
         if ::Rails::VERSION::MAJOR >= 3 && ::Rails::VERSION::MINOR >= 1  # Rails 3.1 lets us override views in engines
           js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript') if options[:controller]
         else # All other rails
-          _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', 'analytical_javascript.html.erb').to_s
+          _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s
           js << options[:controller].send(:render_to_string, :partial=>_partial_path) if options[:controller]
         end
       end

--- a/spec/analytical/api_spec.rb
+++ b/spec/analytical/api_spec.rb
@@ -111,6 +111,16 @@ describe "Analytical::Api" do
           @google.should_receive(:init_javascript).with(:head_append).and_return('google_a')
           @api.head_append_javascript.should == "console_agoogle_a"
         end
+        it 'should render an existing template for Rails 3.0' do
+          @api.options[:javascript_helpers] = true
+          (@api.options[:controller] ||= Object.new).stub!(:render_to_string) { |param| param[:partial] }
+          File.exist?(@api.head_append_javascript).should be_true
+        end
+        it 'should not render an existing template if javascript_helpers is false' do
+          @api.options[:javascript_helpers] = false
+          (@api.options[:controller] ||= Object.new).should_not_receive(:render_to_string)
+          @api.head_append_javascript.should be_blank
+        end
       end
       
       describe '#body_prepend_javascript' do


### PR DESCRIPTION
The template is missing an underscore.

Rails 3.0.9, analytical 3.0.6.

```
    ActionView::Template::Error (Missing partial /home/dblock/.rvm/gems/ruby-1.9.2-p180/gems/analytical-3.0.6/app/views/application/analytical_javascript.html with {:handlers=>[:erb, :rjs, :builder, :rhtml, :rxml, :haml], :formats=>[:html], :locale=>[:en, :en]} in view paths "/home/dblock/source/gravity/dblock/app/views", "/home/dblock/source/gravity/dblock/vendor/plugins/country_select/app/views", "/home/dblock/.rvm/gems/ruby-1.9.2-p180/gems/analytical-3.0.6/app/views", "/home/dblock/.rvm/gems/ruby-1.9.2-p180/gems/devise_invitable-0.5.2/app/views", "/home/dblock/.rvm/gems/ruby-1.9.2-p180/gems/devise-1.4.2/app/views", "/home/dblock/.rvm/gems/ruby-1.9.2-p180/gems/kaminari-0.12.4/app/views"):
        9:     = include_stylesheets :ipad if ipad_device?
        10:     = include_stylesheets :edit_artwork if current_user.has_authorization_to?(:update, Artwork)
        11:     
        12:     = raw analytical.head_append_javascript
        13: 
        14:   %body
        15:     = raw analytical.body_prepend_javascript
      app/views/layouts/client/main.html.haml:12:in `_app_views_layouts_client_main_html_haml__428043036_126237760__535360229'
      app/controllers/application_controller.rb:32:in `block (3 levels) in <class:ApplicationController>'
      app/controllers/application_controller.rb:31:in `block in <class:ApplicationController>'`
```
