### PR TITLE
Use the current Mixpanel API

### DIFF
--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -40,15 +40,8 @@ module Analytical
         "mpmetrics.identify('#{id}');"
       end
 
-      def event(funnel, *args)
-        data = args.last || {}
-        step = data.delete(:step)
-        goal = data.delete(:goal)
-        callback = data.delete(:callback) || "function(){}"
-        return "/* API Error: Funnel is not set for 'mpmetrics.track_funnel(funnel:string, step:int, goal:string, properties:object, callback:function); */" if funnel.blank?
-        return "/* API Error: Step is not set for 'mpmetrics.track_funnel(#{funnel}, ...); */" unless step && step.to_i >= 0
-        return "/* API Error: Goal is not set for 'mpmetrics.track_funnel(#{funnel}, #{step}, ...); */" if goal.blank?
-        "mpmetrics.track_funnel('#{funnel}', '#{step}', '#{goal}', #{data.to_json}, #{callback});"
+      def event(name, attributes = {})
+        "mpmetrics.track('#{name}', #{attributes.to_json});"
       end
 
     end

--- a/spec/analytical/modules/mixpanel_spec.rb
+++ b/spec/analytical/modules/mixpanel_spec.rb
@@ -33,29 +33,7 @@ describe "Analytical::Modules::Mixpanel" do
   describe '#event' do
     it 'should return a js string' do
       @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-      @api.event('My Funnel', {:step=>5, :goal=>'thegoal'}).should == "mpmetrics.track_funnel('My Funnel', '5', 'thegoal', {}, function(){});"
-    end
-    describe 'without the proper data' do
-      it 'should return an error string with blank funnel' do
-        @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-        @api.event('', {:step=>5, :goal=>'thegoal'}).should =~ /Funnel is not set/
-      end
-      it 'should return an error string with blank step' do
-        @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-        @api.event('My Funnel', {:goal=>'thegoal'}).should =~ /Step is not set/
-      end
-      it 'should return an error string with step < 0' do
-        @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-        @api.event('My Funnel', {:step=>-1, :goal=>'thegoal'}).should =~ /Step is not set/
-      end
-      it 'should return an error string with blank goal' do
-        @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-        @api.event('My Funnel', {:step=>5}).should =~ /Goal is not set/
-      end
-    end
-    it 'should return a js string' do
-      @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :js_url_key=>'abcdef'
-      @api.event('My Funnel', {:step=>5, :goal=>'thegoal', :callback=>'thecallback', :other=>'data'}).should == "mpmetrics.track_funnel('My Funnel', '5', 'thegoal', {\"other\":\"data\"}, thecallback);"
+      @api.event('An event happened', { :item => 43 }).should == "mpmetrics.track('An event happened', {\"item\":43});"
     end
   end
   describe '#init_javascript' do


### PR DESCRIPTION
Hi there,

I've updated the Mixpanel module to use the current Mixpanel event tracking API. The track_funnel method that was being used has now been deprecated in favour of sending raw events and building funnels from their web interface.
