### PR TITLE
Fix Rails version check in api.rb

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -72,8 +72,9 @@ module Analytical
         tracking_javascript(:head_append),
       ]
 
-      if options[:javascript_helpers]
-        if ::Rails.version =~ /^3\.[12]/  # Rails 3.1 lets us override views in engines
+      if options[:javascript_helpers] 
+        # Rails 3.1 lets us override views in engines
+        if ( ::Rails::VERSION::MAJOR == 3 and ::Rails::VERSION::MINOR >= 1) or ::Rails::VERSION::MAJOR > 3
           js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript') if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -73,7 +73,7 @@ module Analytical
       ]
 
       if options[:javascript_helpers]
-        if ::Rails::VERSION =~ /^3\.1/  # Rails 3.1 lets us override views in engines
+        if ::Rails.version =~ /^3\.[12]/  # Rails 3.1 lets us override views in engines
           js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript') if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s


### PR DESCRIPTION
This fixes Issue #33

I modified the Rails version check so that it shouldn't break in the future. I guess there are better ways of doing this, but at least it's better than hardcoding version 3.1 to the source.
