### PR TITLE
Fixed the Rails version check.

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -73,7 +73,7 @@ module Analytical
       ]
 
       if options[:javascript_helpers]
-        if ::Rails::VERSION::STRING.to_i >= 3.1  # Rails 3.1 lets us override views in engines
+        if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('3.1.0')  # Rails 3.1 lets us override views in engines
           js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript') if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s


### PR DESCRIPTION
The current version check is:

<pre>
::Rails::VERSION::STRING.to_i >= 3.1
</pre>


This fails because an integer has no decimal portion.  Changing the to_i to to_f would work in this case, but it'll similarly lose the patch level portion of the version number.  The check I'm doing in this pull request uses the same version comparison API that RubyGems uses itself.
