### PR TITLE
don't force KissMetrics to record page views

### DIFF
--- a/lib/analytical/modules/kiss_metrics.rb
+++ b/lib/analytical/modules/kiss_metrics.rb
@@ -22,9 +22,6 @@ module Analytical
             }
             _kms('//i.kissmetrics.com/i.js');_kms('#{options[:js_url_key]}');
           </script>
-          <script type="text/javascript">
-            _kmq.push(['pageView']);
-          </script>
           HTML
           js
         end

--- a/lib/analytical/modules/kiss_metrics.rb
+++ b/lib/analytical/modules/kiss_metrics.rb
@@ -5,6 +5,7 @@ module Analytical
 
       def initialize(options={})
         super
+        check_js_url_key
       end
 
       def init_javascript(location)
@@ -43,6 +44,15 @@ module Analytical
 
       def alias_identity(old_identity, new_identity)
         "_kmq.push([\"alias\", \"#{old_identity}\", \"#{new_identity}\"]);"
+      end
+
+    private
+
+      def check_js_url_key
+        if options[:js_url_key].nil?
+          raise "You didn't provide a js_url_key for kiss_metrics. " +
+            "Add one to your analytical.yml file so KissMetrics will work."
+        end
       end
 
     end

--- a/lib/analytical/modules/kiss_metrics.rb
+++ b/lib/analytical/modules/kiss_metrics.rb
@@ -5,7 +5,6 @@ module Analytical
 
       def initialize(options={})
         super
-        @tracking_command_location = :body_prepend
       end
 
       def init_javascript(location)


### PR DESCRIPTION
There's already an option on the KissMetrics website that will turn this on as part of loading the KissMetrics package. If you want to track every page view, you should just turn that on instead.
