### PR TITLE
Handle missing module names

### DIFF
--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -26,7 +26,7 @@ module Analytical
       config = config[env] if config.has_key?(env)
 
       # List the modules that were configured
-      config = config.reverse_merge(:modules => [])
+      config = {:modules => []}.merge(config || {})
       config.each{|k, v| config[:modules] << k.to_sym if v.is_a?(Hash) }
     end
   end

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -7,16 +7,17 @@ end
 module Analytical
 
   def analytical(options = {})
-    config = Analytical.config
+    config = Analytical.config(options[:config])
     self.analytical_options = options.reverse_merge(config)
   end
 
-  def self.config
-    path = ::Rails.root.join("config/analytical.yml")
+  def self.config(path)
+    path = Pathname.new(path || ::Rails.root.join("config/analytical.yml"))
     return {} unless path.exist?
 
-    # Only read the config one time
-    @configs ||= begin
+    # Only read the config from any given file one time
+    @configs ||= {}
+    @configs[path] ||= begin
       # Read the config out of the file
       config = YAML.load(path.read).with_indifferent_access
 

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -26,7 +26,7 @@ module Analytical
       config = config[env] if config.has_key?(env)
 
       # List the modules that were configured
-      config = {:modules => []}.merge(config || {})
+      config = (config || {}).reverse_merge(:modules => [])
       config.each{|k, v| config[:modules] << k.to_sym if v.is_a?(Hash) }
     end
   end

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -6,27 +6,28 @@ end
 
 module Analytical
 
-  def analytical(options={})
-    self.analytical_options = options
+  def analytical(options = {})
+    config = Analytical.config
+    self.analytical_options = options.reverse_merge(config)
+  end
 
-    config_options = { :modules => [] }
-    File.open("#{::Rails.root}/config/analytical.yml") do |f|
-      file_options = YAML::load(ERB.new(f.read).result).symbolize_keys
-      env = (::Rails.env || :production).to_sym
-      file_options = file_options[env] if file_options.has_key?(env)
-      file_options.each do |k, v|
-        if v.respond_to?(:symbolize_keys)
-          # module configuration
-          config_options[k.to_sym] = v.symbolize_keys
-          config_options[:modules] << k.to_sym unless options && options[:modules]
-        else
-          # regular option
-          config_options[k.to_sym] = v
-        end
-      end if file_options
-    end if File.exists?("#{::Rails.root}/config/analytical.yml")
+  def self.config
+    path = ::Rails.root.join("config/analytical.yml")
+    return {} unless path.exist?
 
-    self.analytical_options = self.analytical_options.reverse_merge config_options
+    # Only read the config one time
+    @configs ||= begin
+      # Read the config out of the file
+      config = YAML.load(path.read).with_indifferent_access
+
+      # Pull out the correct environment (or toplevel if there isn't an env)
+      env = ::Rails.env || :production
+      config = config[env] if config.has_key?(env)
+
+      # List the modules that were configured
+      config = config.reverse_merge(:modules => [])
+      config.each{|k, v| config[:modules] << k.to_sym if v.is_a?(Hash) }
+    end
   end
 
   module InstanceMethods

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -11,7 +11,7 @@ module Analytical
     self.analytical_options = options.reverse_merge(config)
   end
 
-  def self.config(path)
+  def self.config(path = nil)
     path = Pathname.new(path || ::Rails.root.join("config/analytical.yml"))
     return {} unless path.exist?
 

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -11,12 +11,12 @@ module Analytical
 
     def initialize(options={})
       @options = options
-      @modules = @options[:modules].inject(ActiveSupport::OrderedHash.new) do |h, m|
+      @modules = ActiveSupport::OrderedHash.new
+      @options[:modules].each do |m|
         module_options = @options.merge(@options[m] || {})
         module_options.delete(:modules)
         module_options[:session_store] = Analytical::SessionCommandStore.new(@options[:session], m) if @options[:session]
-        h[m] = get_mod(m).new(module_options)
-        h
+        @modules[m] = get_mod(m).new(module_options)
       end
       @dummy_module = Analytical::Modules::DummyModule.new
     end

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -15,10 +15,18 @@ module Analytical
         module_options = @options.merge(@options[m] || {})
         module_options.delete(:modules)
         module_options[:session_store] = Analytical::SessionCommandStore.new(@options[:session], m) if @options[:session]
-        h[m] = "Analytical::Modules::#{m.to_s.camelize}".constantize.new(module_options)
+        h[m] = get_mod(m).new(module_options)
         h
       end
       @dummy_module = Analytical::Modules::DummyModule.new
+    end
+
+    def get_mod(name)
+      name = name.to_s.camelize
+      "Analytical::Modules::#{name}".constantize
+    rescue NameError
+      raise "You're trying to configure a module named '#{name}', but " +
+        "Analytical doesn't have one. Check your analytical.yml file for typos."
     end
 
     #


### PR DESCRIPTION
This pull request adds a rescue block to the code that loads modules based on the config. If a module doesn't exist, it explains why there is an error, and suggests that you fix your analytical.yml file.

I meant to just fix this to handle missing module names better, but I wound up accidentally rewriting the config file loading code. If you want them as separate pull requests, just let me know.
