### PR TITLE
Only add setDomainName if the :domain key is set, just like allowLinker....

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -15,7 +15,7 @@ module Analytical
           <script type="text/javascript">
             var _gaq = _gaq || [];
             _gaq.push(['_setAccount', '#{options[:key]}']);
-            _gaq.push(['_setDomainName', '#{options[:domain]}']);
+            #{"_gaq.push(['_setDomainName', '#{options[:domain]}']);" if options[:domain]}
             #{"_gaq.push(['_setAllowLinker', true]);" if options[:allow_linker]}
             _gaq.push(['_trackPageview']);
             (function() {


### PR DESCRIPTION
... Seems weird to _setDomainName '' if you're tracking a single site

Is there history around this or something else that I'm missing
