### PR TITLE
Hard-code the HTML format for the analytical_javascript partial.

### DIFF
--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -82,7 +82,7 @@ module Analytical
 
       if options[:javascript_helpers]
         if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('3.1.0')  # Rails 3.1 lets us override views in engines
-          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript.html.erb') if options[:controller]
+          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript.html') if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s
           js << options[:controller].send(:render_to_string, :file=>_partial_path, :layout=>false) if options[:controller]

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -82,7 +82,7 @@ module Analytical
 
       if options[:javascript_helpers]
         if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('3.1.0')  # Rails 3.1 lets us override views in engines
-          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript.html') if options[:controller]
+          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript', :formats => [:html], :handlers => [:erb]) if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s
           js << options[:controller].send(:render_to_string, :file=>_partial_path, :layout=>false) if options[:controller]

--- a/lib/analytical/api.rb
+++ b/lib/analytical/api.rb
@@ -82,7 +82,7 @@ module Analytical
 
       if options[:javascript_helpers]
         if Gem::Version.new(::Rails::VERSION::STRING) >= Gem::Version.new('3.1.0')  # Rails 3.1 lets us override views in engines
-          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript') if options[:controller]
+          js << options[:controller].send(:render_to_string, :partial=>'analytical_javascript.html.erb') if options[:controller]
         else # All other rails
           _partial_path = Pathname.new(__FILE__).dirname.join('..', '..', 'app/views/application', '_analytical_javascript.html.erb').to_s
           js << options[:controller].send(:render_to_string, :file=>_partial_path, :layout=>false) if options[:controller]


### PR DESCRIPTION
Currently the analytical_javascript partial is referenced without its format/extension. By default, rails will search only for the format/extension of the including page. This can be problematic for apps that use formats other than HTML.

For example, we have a format called "iphone", which we use to render mobile-optimized views using the same controllers as their html counterparts. This PR makes the format/extension explicit so that analytical can be called safely from any page/format.
