### PR TITLE
Kissmetrics id fallback

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,6 @@ group :development, :test do
   gem 'diff-lcs'
   gem 'guard'
   gem 'guard-rspec'
-  gem 'rb-fsevent'
+  gem 'rb-fsevent', ">= 0.9.2"
   gem 'growl'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,7 +78,7 @@ GEM
       rdoc (~> 3.4)
       thor (~> 0.14.4)
     rake (0.9.2)
-    rb-fsevent (0.4.0)
+    rb-fsevent (0.9.2)
     rdoc (3.6.1)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
@@ -110,7 +110,7 @@ DEPENDENCIES
   guard-rspec
   jeweler
   rails (= 3.0.9)
-  rb-fsevent
+  rb-fsevent (>= 0.9.2)
   rspec (= 2.6.0)
   rspec-core (= 2.6.4)
   rspec-expectations (= 2.6.0)

--- a/lib/analytical/modules/kiss_metrics.rb
+++ b/lib/analytical/modules/kiss_metrics.rb
@@ -29,7 +29,8 @@ module Analytical
 
       def identify(id, *args)
         data = args.first || {}
-        "_kmq.push([\"identify\", \"#{data[:email]}\"]);"
+        km_id = data[:email] || id
+        "_kmq.push([\"identify\", \"#{ km_id }\"]);"
       end
 
       def event(name, *args)

--- a/spec/analytical/modules/kiss_metrics_spec.rb
+++ b/spec/analytical/modules/kiss_metrics_spec.rb
@@ -19,6 +19,10 @@ describe "Analytical::Modules::KissMetrics" do
       @api = Analytical::Modules::KissMetrics.new :parent=>@parent, :js_url_key=>'abcdef'
       @api.identify('id', {:email=>'test@test.com'}).should == "_kmq.push([\"identify\", \"test@test.com\"]);"
     end
+    it 'uses the id parameter when the email parameter is not present' do
+      @api = Analytical::Modules::KissMetrics.new :parent=>@parent, :js_url_key=>'abcdef'
+      @api.identify('id').should == "_kmq.push([\"identify\", \"id\"]);"
+    end
   end
   describe '#event' do
     it 'should return a js string' do

--- a/spec/analytical_spec.rb
+++ b/spec/analytical_spec.rb
@@ -69,17 +69,18 @@ describe "Analytical" do
     end
 
     it 'should open the initialization file' do
-      File.should_receive(:'exists?').with("#{Rails.root}/config/analytical.yml").and_return(true)
+      FileTest.should_receive(:'exist?').with("#{Rails.root}/config/analytical.yml").and_return(true)
       DummyForInit.analytical
-      DummyForInit.analytical_options[:google].should == {:key=>'google_12345'}
-      DummyForInit.analytical_options[:kiss_metrics].should == {:key=>'kiss_metrics_12345'}
-      DummyForInit.analytical_options[:clicky].should == {:key=>'clicky_12345'}
-      DummyForInit.analytical_options[:chartbeat].should == {:key=>'chartbeat_12345', :domain => 'your.domain.com'}
+      DummyForInit.analytical_options[:google][:key].should == 'google_12345'
+      DummyForInit.analytical_options[:kiss_metrics][:key].should == 'kiss_metrics_12345'
+      DummyForInit.analytical_options[:clicky][:key].should == 'clicky_12345'
+      DummyForInit.analytical_options[:chartbeat][:key].should == 'chartbeat_12345'
+      DummyForInit.analytical_options[:chartbeat][:domain].should == 'your.domain.com'
     end
 
     it 'should allow for module-specific controller overrides' do
       DummyForInit.analytical :google=>{:key=>'override_google_key'}
-      DummyForInit.analytical_options[:google].should == {:key=>'override_google_key'}
+      DummyForInit.analytical_options[:google][:key].should == 'override_google_key'
     end
 
     describe 'in production mode' do

--- a/spec/config/analytical.yml
+++ b/spec/config/analytical.yml
@@ -9,6 +9,7 @@ test:
     key: clicky_12345
   kiss_metrics:
     key: kiss_metrics_12345
+    js_url_key: kiss_metrics_js_url_12345
   chartbeat:
     key: chartbeat_12345
     domain: your.domain.com


### PR DESCRIPTION
This request allows KissMetrics #identify to fall back to using the id parameter when :email is not provided. 

I need the two preceding commits to get tests working and bundle install working.
