### PR TITLE
Mixpanel script update

### DIFF
--- a/lib/analytical/modules/mixpanel.rb
+++ b/lib/analytical/modules/mixpanel.rb
@@ -15,14 +15,14 @@ module Analytical
           <script type="text/javascript">
             (function(c,a){window.mixpanel=a;var b,d,h,e;b=c.createElement("script");
             b.type="text/javascript";b.async=!0;b.src=("https:"===c.location.protocol?"https:":"http:")+
-            '//cdn.mxpnl.com/libs/mixpanel-2.1.min.js';d=c.getElementsByTagName("script")[0];
+            '//cdn.mxpnl.com/libs/mixpanel-2.2.min.js';d=c.getElementsByTagName("script")[0];
             d.parentNode.insertBefore(b,d);a._i=[];a.init=function(b,c,f){function d(a,b){
             var c=b.split(".");2==c.length&&(a=a[c[0]],b=c[1]);a[b]=function(){a.push([b].concat(
             Array.prototype.slice.call(arguments,0)))}}var g=a;"undefined"!==typeof f?g=a[f]=[]:
             f="mixpanel";g.people=g.people||[];h=['disable','track','track_pageview','track_links',
-            'track_forms','register','register_once','unregister','identify','name_tag',
-            'set_config','people.identify','people.set','people.increment'];for(e=0;e<h.length;e++)d(g,h[e]);
-            a._i.push([b,c,f])};a.__SV=1.1;})(document,window.mixpanel||[]);
+            'track_forms','register','register_once','unregister','identify','alias','name_tag',
+            'set_config','people.set','people.increment','people.track_charge','people.append'];
+            for(e=0;e<h.length;e++)d(g,h[e]);a._i.push([b,c,f])};a.__SV=1.2;})(document,window.mixpanel||[]);
             mixpanel.init("#{options[:key]}");
           </script>
           HTML

--- a/spec/analytical/modules/mixpanel_spec.rb
+++ b/spec/analytical/modules/mixpanel_spec.rb
@@ -46,7 +46,7 @@ describe "Analytical::Modules::Mixpanel" do
       @api.init_javascript(:head_prepend).should == ''
       @api.init_javascript(:head_append).should == ''
       @api.init_javascript(:body_prepend).should == ''
-      @api.init_javascript(:body_append).should =~ %r(cdn\.mxpnl\.com\/libs/mixpanel-2\.1\.min\.js)
+      @api.init_javascript(:body_append).should =~ %r(cdn\.mxpnl\.com\/libs/mixpanel-2\.2\.min\.js)
       @api.init_javascript(:body_append).should =~ %r(mixpanel\.init\("abcdef"\))
       @api.init_javascript(:body_append).should =~ %r(<script type="text\/javascript">)
     end


### PR DESCRIPTION
Here is the latest update update to the mixpanel script (version 2.2). It adds a few more helpful methods (alias, people.track_charge, people.append).
