### PR TITLE
Add option for dynamic modules

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -91,6 +91,25 @@ This can be useful for enabling the console logger optionally in your app, based
       controller.use_console_logger? ? [:console] : modules
     }
 
+It is also possible to dynamically specify what modules to use, which can come in handy if your site uses multi-tenancy, and if you need specific modules or keys for specific tenants.
+
+    analytical :dynamic_modules => lambda{ |controller| controller.analytical_modules }
+
+In this case we would then implement a method in your controller that could look like this:
+
+    def analytical_modules
+      case current_tenant.name.parameterize
+      when "site-1"
+        {
+          :google => { key: 'UA-5555555-5' }
+        }
+      when "site-2"
+        {
+          :google => { key: 'UA-1111111-1' }
+        }
+      end
+    end
+    hide_action :analytical_modules
 
 == Adding new modules
 

--- a/README.rdoc
+++ b/README.rdoc
@@ -40,7 +40,7 @@ Add a configuration file (config/analytical.yml) to declare your API keys, like 
    development:
    test:
 
-You can add different configurations for different environments. 
+You can add different configurations for different environments.
 
 By default, all the declared analytics modules are loaded. You can override this behavior in the controller.
 
@@ -91,11 +91,15 @@ This can be useful for enabling the console logger optionally in your app, based
       controller.use_console_logger? ? [:console] : modules
     }
 
-It is also possible to dynamically specify what modules to use, which can come in handy if your site uses multi-tenancy, and if you need specific modules or keys for specific tenants.
+You can also configure modules in the controller by passing a hash to the :modules option
 
-    analytical :dynamic_modules => lambda{ |controller| controller.analytical_modules }
+    analytical :modules => { :google => { key: 'UA-5555555-5' } }
 
-In this case we would then implement a method in your controller that could look like this:
+Finally it is also possible to dynamically specify what modules to use and their configurations, which can come in handy if your site uses multi-tenancy, where every tenant might not wish to use the same modules or configurations for each module.
+
+    analytical :modules => lambda{ |controller| controller.analytical_modules }
+
+In this case we would then implement a method in the controller that could look like this:
 
     def analytical_modules
       case current_tenant.name.parameterize
@@ -170,6 +174,7 @@ These fine folks have contributed patches and new features to this project:
 * {Kurt Werle}[http://github.com/kwerle]
 * {Olivier Lauzon}[http://github.com/olauzon]
 * {Chris Ricca}[https://github.com/ChrisRicca]
+* {Thomas Dippel}[https://github.com/dipth]
 
 Thanks guys!
 

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -36,6 +36,13 @@ module Analytical
           :ssl => request.ssl?,
           :controller => self,
         })
+        if options[:dynamic_modules]
+          modules = options[:dynamic_modules].call(self)
+          modules.each do |k,v|
+            options[k.to_sym] = v.symbolize_keys
+            options[:modules] << k.to_sym
+          end
+        end
         if options[:disable_if] && options[:disable_if].call(self)
           options[:modules] = []
         end

--- a/lib/analytical.rb
+++ b/lib/analytical.rb
@@ -36,12 +36,14 @@ module Analytical
           :ssl => request.ssl?,
           :controller => self,
         })
-        if options[:dynamic_modules]
-          modules = options[:dynamic_modules].call(self)
-          modules.each do |k,v|
+        if options[:modules] && (options[:modules].is_a?(Hash) || options[:modules].is_a?(Proc))
+          items = options[:modules].is_a?(Hash) ? options[:modules] : options[:modules].call(self)
+          modules = []
+          items.each do |k,v|
             options[k.to_sym] = v.symbolize_keys
-            options[:modules] << k.to_sym
+            modules << k.to_sym
           end
+          options[:modules] = modules
         end
         if options[:disable_if] && options[:disable_if].call(self)
           options[:modules] = []

--- a/spec/analytical_spec.rb
+++ b/spec/analytical_spec.rb
@@ -15,8 +15,8 @@ describe "Analytical" do
 
       def self.helper_method(*a); end
       def request
-        RSpec::Mocks::Mock.new 'request', 
-          :'ssl?'=>true, 
+        RSpec::Mocks::Mock.new 'request',
+          :'ssl?'=>true,
           :user_agent=>'Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.6; en-US; rv:1.9.2.3) Gecko/20100401 Firefox/3.6.3 GTB7.0'
       end
     end
@@ -30,13 +30,21 @@ describe "Analytical" do
       d.options[:string_option].should == "string"
     end
 
-    it 'should load modules from lambda when dynamic_modules option is set' do
+    it 'should load module configurations from hash' do
+      options = { :modules => { :console => { :some_key => 'rubberduck' } }}
+      DummyForInit.analytical options
+      a = DummyForInit.new.analytical
+      a.options[:modules].should include(:console)
+      a.options[:console].should eq({ :some_key => 'rubberduck' })
+    end
+
+    it 'should load module configurations from a lambda' do
       class DummyForInit
         def analytical_modules
           { :console => { :some_key => 'rubberduck' } }
         end
       end
-      options = { :dynamic_modules => lambda { |controller| controller.analytical_modules }}
+      options = { :modules => lambda { |controller| controller.analytical_modules }}
       DummyForInit.analytical options
       a = DummyForInit.new.analytical
       a.options[:modules].should include(:console)
@@ -55,12 +63,12 @@ describe "Analytical" do
       d = DummyForInit.new.analytical
       d.options[:modules].should == [:google]
     end
-    
+
     describe 'conditionally disabled' do
       it 'should set the modules to []' do
         DummyForInit.analytical :disable_if => lambda { |x| true }
         d = DummyForInit.new
-        d.analytical.options[:modules].should == []        
+        d.analytical.options[:modules].should == []
       end
     end
 

--- a/spec/analytical_spec.rb
+++ b/spec/analytical_spec.rb
@@ -30,6 +30,19 @@ describe "Analytical" do
       d.options[:string_option].should == "string"
     end
 
+    it 'should load modules from lambda when dynamic_modules option is set' do
+      class DummyForInit
+        def analytical_modules
+          { :console => { :some_key => 'rubberduck' } }
+        end
+      end
+      options = { :dynamic_modules => lambda { |controller| controller.analytical_modules }}
+      DummyForInit.analytical options
+      a = DummyForInit.new.analytical
+      a.options[:modules].should include(:console)
+      a.options[:console].should eq({ :some_key => 'rubberduck' })
+    end
+
     it 'should preserve :javascript_helpers option' do
       options = { :javascript_helpers => false, :modules => [] }
       DummyForInit.analytical options


### PR DESCRIPTION
Especially handy in a multi-tenancy setup where each tenant might not want the same modules and keys.
