### PR TITLE
Mixpanel: track page views as a single event, and allow optionally disabling of page view tracking

### DIFF
--- a/spec/analytical/modules/mixpanel_spec.rb
+++ b/spec/analytical/modules/mixpanel_spec.rb
@@ -27,12 +27,21 @@ describe "Analytical::Modules::Mixpanel" do
   describe '#track' do
     it 'should return the tracking javascript' do
       @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :key=>'abcdef'
-      @api.track('pagename', {:some=>'data'}).should == "mixpanel.track(\"pagename\", {\"some\":\"data\"}, function(){});"
+      @api.track('pagename', {'page title'=>'lovely day'}).should == "mixpanel.track(\"page viewed\", {\"url\":\"pagename\",\"page title\":\"lovely day\"}, function(){});"
     end
     it 'should return the tracking javascript with a callback' do
       @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :key=>'abcdef'
-      @api.track('pagename', {:some=>'data', :callback=>'fubar'}).should == "mixpanel.track(\"pagename\", {\"some\":\"data\"}, fubar);"
+      @api.track('pagename', {'page title'=>'lovely day', :callback=>'fubar'}).should == "mixpanel.track(\"page viewed\", {\"url\":\"pagename\",\"page title\":\"lovely day\"}, fubar);"
     end
+    it 'should return the tracking javascript with a custom event name' do
+      @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :key=>'abcdef'
+      @api.track('pagename', {:event=>'virtual pageview'}).should == "mixpanel.track(\"virtual pageview\", {\"url\":\"pagename\"}, function(){});"
+    end
+    it 'should return nil when Mixpanel pageview tracking is disabled' do
+      @api = Analytical::Modules::Mixpanel.new :parent=>@parent, :key=>'abcdef', :track => false
+      @api.track('pagename', {'page title'=>'lovely day', :callback=>'fubar'}).should be_nil
+    end
+
   end
   describe '#event' do
     it 'should return a js string' do


### PR DESCRIPTION
This change breaks compatibility for page view tracking via Mixpanel.

Previously, each page view was logged as a distinct event, with the URL as the name of
the event. This can result in many events, if you track many different URLs.

As of this commit the Mixpanel module logs each page view as an instance of the "page viewed" event.

This change confirms with a recommendation in the Mixpanel docs. See here:
  https://mixpanel.com/docs/getting-started/events-vs-page-views

To revert to the old behavior, use track(url, event: url) to specify the URL as the event name.

To disable page view tracking altogether in Mixpanel, initialize analytical with a { track: false }
option for the mixpanel module.

Lastly, the method signature for #track in this module now matches the method signature used elsewhere in the analytical gem.
