### PR TITLE
Enhanced Link Attribution plugin in Google Analytics

### DIFF
--- a/lib/analytical/modules/google.rb
+++ b/lib/analytical/modules/google.rb
@@ -18,6 +18,7 @@ module Analytical
             #{"_gaq.push(['_setDomainName', '#{options[:domain]}']);" if options[:domain]}
             #{"_gaq.push(['_setAllowLinker', true]);" if options[:allow_linker]}
             #{"_gaq.push(['_setSiteSpeedSampleRate', #{options[:sample_rate]}]);" if options[:sample_rate]}
+            #{"_gaq.push(['_require', 'inpage_linkid', '//www.google-analytics.com/plugins/ga/inpage_linkid.js']);" if options[:enhanced_link_attribution]}
             _gaq.push(['_trackPageview']);
             (function() {
               var ga = document.createElement('script'); ga.type = 'text/javascript'; ga.async = true;

--- a/spec/analytical/modules/google_spec.rb
+++ b/spec/analytical/modules/google_spec.rb
@@ -108,5 +108,13 @@ describe "Analytical::Modules::Google" do
       @api.init_javascript(:body_prepend).should == ''
       @api.init_javascript(:body_append).should == ''
     end
+
+    it 'should include enhanced link attribution code if required' do
+      @api = Analytical::Modules::Google.new :parent=>@parent, :key=>'abcdef', :enhanced_link_attribution => true
+      @api.init_javascript(:head_append).should =~ /plugins\/ga\/inpage_linkid\.js/
+
+      @api = Analytical::Modules::Google.new :parent=>@parent, :key=>'abcdef', :enhanced_link_attribution => false
+      @api.init_javascript(:head_append).should_not =~ /plugins\/ga\/inpage_linkid\.js/
+    end
   end
 end


### PR DESCRIPTION
- Added the boolean configuration option: enhanced_link_attribution
  that adds code to enable that google analytics functionality as
  explained in the following article:
  https://support.google.com/analytics/answer/2558867?hl=en
